### PR TITLE
Update command format

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -1,11 +1,15 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GITHUB_USERNAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NUS_ID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SOC_USERNAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TUTORIAL_GROUP;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
@@ -20,20 +24,26 @@ public class AddCommand extends Command {
 
     public static final String COMMAND_WORD = "add";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the address book. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a student to the address book. "
             + "Parameters: "
             + PREFIX_NAME + "NAME "
-            + PREFIX_PHONE + "PHONE "
+            + PREFIX_NUS_ID + "NUS_ID "
+            + PREFIX_ROLE + "ROLE "
+            + PREFIX_SOC_USERNAME + "SOC_USERNAME "
+            + PREFIX_GITHUB_USERNAME + "GITHUB_USERNAME "
             + PREFIX_EMAIL + "EMAIL "
-            + PREFIX_ADDRESS + "ADDRESS "
+            + PREFIX_PHONE + "PHONE "
+            + PREFIX_TUTORIAL_GROUP + "TUTORIAL_GROUP "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "
-            + PREFIX_PHONE + "98765432 "
-            + PREFIX_EMAIL + "johnd@example.com "
-            + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
-            + PREFIX_TAG + "friends "
-            + PREFIX_TAG + "owesMoney";
+            + PREFIX_NUS_ID + "A0234567B "
+            + PREFIX_ROLE + "tutor "
+            + PREFIX_SOC_USERNAME + "johndoe "
+            + PREFIX_GITHUB_USERNAME + "johndoe "
+            + PREFIX_EMAIL + "johndoe@u.nus.edu "
+            + PREFIX_PHONE + "91234567 "
+            + PREFIX_TUTORIAL_GROUP + "T01";
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -1,11 +1,15 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GITHUB_USERNAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NUS_ID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SOC_USERNAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TUTORIAL_GROUP;
 
 import java.util.Set;
 import java.util.stream.Stream;
@@ -24,6 +28,9 @@ import seedu.address.model.tag.Tag;
  */
 public class AddCommandParser implements Parser<AddCommand> {
 
+    // TODO: Remove stub when Person supports tutorial group and other new add fields.
+    private static final String STUB_ADDRESS_VALUE = "-";
+
     /**
      * Parses the given {@code String} of arguments in the context of the AddCommand
      * and returns an AddCommand object for execution.
@@ -31,18 +38,28 @@ public class AddCommandParser implements Parser<AddCommand> {
      */
     public AddCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
+            ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_NUS_ID, PREFIX_ROLE, PREFIX_SOC_USERNAME,
+                PREFIX_GITHUB_USERNAME, PREFIX_EMAIL, PREFIX_PHONE, PREFIX_TUTORIAL_GROUP, PREFIX_TAG);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ADDRESS, PREFIX_PHONE, PREFIX_EMAIL)
+        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_NUS_ID, PREFIX_ROLE, PREFIX_SOC_USERNAME,
+            PREFIX_GITHUB_USERNAME, PREFIX_EMAIL, PREFIX_PHONE, PREFIX_TUTORIAL_GROUP)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_NUS_ID, PREFIX_ROLE, PREFIX_SOC_USERNAME,
+            PREFIX_GITHUB_USERNAME, PREFIX_EMAIL, PREFIX_PHONE, PREFIX_TUTORIAL_GROUP);
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
-        Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
+        // TODO: Persist these parsed values when domain/model fields are implemented.
+        ParserUtil.parseNusId(argMultimap.getValue(PREFIX_NUS_ID).get());
+        ParserUtil.parseRole(argMultimap.getValue(PREFIX_ROLE).get());
+        ParserUtil.parseSocUsername(argMultimap.getValue(PREFIX_SOC_USERNAME).get());
+        ParserUtil.parseGithubUsername(argMultimap.getValue(PREFIX_GITHUB_USERNAME).get());
+        ParserUtil.parseTutorialGroup(argMultimap.getValue(PREFIX_TUTORIAL_GROUP).get());
+
+        Address address = new Address(STUB_ADDRESS_VALUE);
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
         Person person = new Person(name, phone, email, address, tagList);

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -13,6 +13,8 @@ public class CliSyntax {
     public static final Prefix PREFIX_GITHUB_USERNAME = new Prefix("gh/");
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_PHONE = new Prefix("p/");
+    // TODO: Remove after all commands/tests are migrated away from address field.
+    public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_TUTORIAL_GROUP = new Prefix("t/");
     public static final Prefix PREFIX_TAG = new Prefix("tag/");
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
@@ -21,6 +22,24 @@ import seedu.address.model.tag.Tag;
 public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
+    public static final String MESSAGE_NUS_ID_CONSTRAINTS = "NUS ID must be in the format "
+        + "A#######X where # is a digit and X is an uppercase letter (e.g., A0234567B).";
+    public static final String MESSAGE_ROLE_CONSTRAINTS = "Invalid Role. The role must be student / tutor.";
+    public static final String MESSAGE_SOC_USERNAME_CONSTRAINTS = "SOC username must be 5-8 characters "
+        + "(or a valid NUS-ID form), using only lowercase letters, digits, and hyphens, "
+        + "and cannot start or end with a hyphen.";
+    public static final String MESSAGE_GITHUB_USERNAME_CONSTRAINTS = "GitHub username must be 1-39 characters, "
+        + "containing only alphanumeric characters or hyphens, and cannot start or end with a hyphen.";
+    public static final String MESSAGE_TUTORIAL_GROUP_CONSTRAINTS = "Tutorial group must be in the format "
+        + "T## where # is a digit (e.g., T01, T12).";
+
+    private static final String NUS_ID_REGEX = "A[0-9]{7}[A-Z]";
+    private static final String ROLE_STUDENT = "student";
+    private static final String ROLE_TUTOR = "tutor";
+    private static final String SOC_ALLOWED_CHARS_REGEX = "[a-z0-9-]+";
+    private static final String SOC_NUS_ID_FORM_REGEX = "[a-z][0-9]{7}[a-z]";
+    private static final String GITHUB_USERNAME_REGEX = "[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?";
+    private static final String TUTORIAL_GROUP_REGEX = "T[0-9]{2}";
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
@@ -120,5 +139,101 @@ public class ParserUtil {
             tagSet.add(parseTag(tagName));
         }
         return tagSet;
+    }
+
+    /**
+     * Parses a {@code String nusId} into a normalized NUS ID.
+     * Leading and trailing whitespaces will be trimmed.
+     * TODO: Return a NusId domain object after the model class is introduced.
+     */
+    public static String parseNusId(String nusId) throws ParseException {
+        requireNonNull(nusId);
+        String trimmedNusId = nusId.trim();
+        String normalizedNusId = trimmedNusId.toUpperCase(Locale.ROOT);
+        if (containsWhitespace(trimmedNusId) || !normalizedNusId.matches(NUS_ID_REGEX)) {
+            throw new ParseException(MESSAGE_NUS_ID_CONSTRAINTS);
+        }
+        return normalizedNusId;
+    }
+
+    /**
+     * Parses a {@code String role} into a normalized role.
+     * Leading and trailing whitespaces will be trimmed.
+     * TODO: Return a Role domain object after the model class is introduced.
+     */
+    public static String parseRole(String role) throws ParseException {
+        requireNonNull(role);
+        String trimmedRole = role.trim();
+        if (containsWhitespace(trimmedRole)) {
+            throw new ParseException(MESSAGE_ROLE_CONSTRAINTS);
+        }
+
+        String normalizedRole = trimmedRole.toLowerCase(Locale.ROOT);
+        if (!ROLE_STUDENT.equals(normalizedRole) && !ROLE_TUTOR.equals(normalizedRole)) {
+            throw new ParseException(MESSAGE_ROLE_CONSTRAINTS);
+        }
+        return normalizedRole;
+    }
+
+    /**
+     * Parses a {@code String socUsername} into a validated SOC username.
+     * Leading and trailing whitespaces will be trimmed.
+     * TODO: Return a SocUsername domain object after the model class is introduced.
+     */
+    public static String parseSocUsername(String socUsername) throws ParseException {
+        requireNonNull(socUsername);
+        String trimmedSocUsername = socUsername.trim();
+
+        if (containsWhitespace(trimmedSocUsername)
+                || !trimmedSocUsername.matches(SOC_ALLOWED_CHARS_REGEX)
+                || trimmedSocUsername.startsWith("-")
+                || trimmedSocUsername.endsWith("-")) {
+            throw new ParseException(MESSAGE_SOC_USERNAME_CONSTRAINTS);
+        }
+
+        if (trimmedSocUsername.matches(SOC_NUS_ID_FORM_REGEX)) {
+            return trimmedSocUsername;
+        }
+
+        if (trimmedSocUsername.length() < 5 || trimmedSocUsername.length() > 8) {
+            throw new ParseException(MESSAGE_SOC_USERNAME_CONSTRAINTS);
+        }
+
+        return trimmedSocUsername;
+    }
+
+    /**
+     * Parses a {@code String githubUsername} into a validated GitHub username.
+     * Leading and trailing whitespaces will be trimmed.
+     * TODO: Return a GithubUsername domain object after the model class is introduced.
+     */
+    public static String parseGithubUsername(String githubUsername) throws ParseException {
+        requireNonNull(githubUsername);
+        String trimmedGithubUsername = githubUsername.trim();
+        if (containsWhitespace(trimmedGithubUsername)
+                || trimmedGithubUsername.contains("--")
+                || !trimmedGithubUsername.matches(GITHUB_USERNAME_REGEX)) {
+            throw new ParseException(MESSAGE_GITHUB_USERNAME_CONSTRAINTS);
+        }
+        return trimmedGithubUsername;
+    }
+
+    /**
+     * Parses a {@code String tutorialGroup} into a normalized tutorial group.
+     * Leading and trailing whitespaces will be trimmed.
+     * TODO: Return a TutorialGroup domain object after the model class is introduced.
+     */
+    public static String parseTutorialGroup(String tutorialGroup) throws ParseException {
+        requireNonNull(tutorialGroup);
+        String trimmedTutorialGroup = tutorialGroup.trim();
+        String normalizedTutorialGroup = trimmedTutorialGroup.toUpperCase(Locale.ROOT);
+        if (containsWhitespace(trimmedTutorialGroup) || !normalizedTutorialGroup.matches(TUTORIAL_GROUP_REGEX)) {
+            throw new ParseException(MESSAGE_TUTORIAL_GROUP_CONSTRAINTS);
+        }
+        return normalizedTutorialGroup;
+    }
+
+    private static boolean containsWhitespace(String value) {
+        return value.chars().anyMatch(Character::isWhitespace);
     }
 }

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -32,6 +32,7 @@ import seedu.address.storage.JsonAddressBookStorage;
 import seedu.address.storage.JsonUserPrefsStorage;
 import seedu.address.storage.StorageManager;
 import seedu.address.testutil.PersonBuilder;
+import seedu.address.testutil.PersonUtil;
 
 public class LogicManagerTest {
     private static final IOException DUMMY_IO_EXCEPTION = new IOException("dummy IO exception");
@@ -165,9 +166,8 @@ public class LogicManagerTest {
         logic = new LogicManager(model, storage);
 
         // Triggers the saveAddressBook method by executing an add command
-        String addCommand = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY
-                + EMAIL_DESC_AMY + ADDRESS_DESC_AMY;
-        Person expectedPerson = new PersonBuilder(AMY).withTags().build();
+        Person expectedPerson = new PersonBuilder(AMY).withAddress("-").withTags().build();
+        String addCommand = PersonUtil.getAddCommand(expectedPerson);
         ModelManager expectedModel = new ModelManager();
         expectedModel.addPerson(expectedPerson);
         assertCommandFailure(addCommand, CommandException.class, expectedMessage, expectedModel);

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -1,41 +1,23 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
-import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
-import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
-import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.Messages.getErrorMessageForDuplicatePrefixes;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GITHUB_USERNAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NUS_ID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SOC_USERNAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TUTORIAL_GROUP;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.testutil.TypicalPersons.AMY;
-import static seedu.address.testutil.TypicalPersons.BOB;
+
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.logic.Messages;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
@@ -43,98 +25,65 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
-import seedu.address.testutil.PersonBuilder;
 
 public class AddCommandParserTest {
     private AddCommandParser parser = new AddCommandParser();
+    private static final String VALID_NAME = "John Doe";
+    private static final String VALID_NUS_ID = "A0234567B";
+    private static final String VALID_ROLE = "student";
+    private static final String VALID_SOC = "johndoe";
+    private static final String VALID_GITHUB = "john-doe";
+    private static final String VALID_EMAIL = "john@u.nus.edu";
+    private static final String VALID_PHONE = "91234567";
+    private static final String VALID_TUTORIAL = "T01";
+    private static final String VALID_TAG_ONE = "struggling";
+        private static final String VALID_TAG_TWO = "pythonexperienced";
+
+    private static final String NAME_DESC = " " + PREFIX_NAME + VALID_NAME;
+    private static final String NUS_ID_DESC = " " + PREFIX_NUS_ID + VALID_NUS_ID;
+    private static final String ROLE_DESC = " " + PREFIX_ROLE + VALID_ROLE;
+    private static final String SOC_DESC = " " + PREFIX_SOC_USERNAME + VALID_SOC;
+    private static final String GITHUB_DESC = " " + PREFIX_GITHUB_USERNAME + VALID_GITHUB;
+    private static final String EMAIL_DESC = " " + PREFIX_EMAIL + VALID_EMAIL;
+    private static final String PHONE_DESC = " " + PREFIX_PHONE + VALID_PHONE;
+    private static final String TUTORIAL_DESC = " " + PREFIX_TUTORIAL_GROUP + VALID_TUTORIAL;
+    private static final String TAG_ONE_DESC = " " + PREFIX_TAG + VALID_TAG_ONE;
+    private static final String TAG_TWO_DESC = " " + PREFIX_TAG + VALID_TAG_TWO;
+
+    private static final String VALID_ADD_INPUT = NAME_DESC + NUS_ID_DESC + ROLE_DESC + SOC_DESC
+            + GITHUB_DESC + EMAIL_DESC + PHONE_DESC + TUTORIAL_DESC;
 
     @Test
     public void parse_allFieldsPresent_success() {
-        Person expectedPerson = new PersonBuilder(BOB).withTags(VALID_TAG_FRIEND).build();
+        Person expectedPerson = new Person(
+                new Name(VALID_NAME),
+                new Phone(VALID_PHONE),
+                new Email(VALID_EMAIL),
+                new Address("-"),
+                Set.of(new Tag(VALID_TAG_ONE), new Tag(VALID_TAG_TWO)));
 
-        // whitespace only preamble
-        assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedPerson));
-
-
-        // multiple tags - all accepted
-        Person expectedPersonMultipleTags = new PersonBuilder(BOB).withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND)
-                .build();
-        assertParseSuccess(parser,
-                NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
-                new AddCommand(expectedPersonMultipleTags));
+        assertParseSuccess(parser, "   " + VALID_ADD_INPUT + TAG_ONE_DESC + TAG_TWO_DESC,
+                new AddCommand(expectedPerson));
     }
 
     @Test
     public void parse_repeatedNonTagValue_failure() {
-        String validExpectedPersonString = NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_FRIEND;
+        assertParseFailure(parser, VALID_ADD_INPUT + " " + PREFIX_PHONE + "81234567",
+                getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
 
-        // multiple names
-        assertParseFailure(parser, NAME_DESC_AMY + validExpectedPersonString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME));
-
-        // multiple phones
-        assertParseFailure(parser, PHONE_DESC_AMY + validExpectedPersonString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
-
-        // multiple emails
-        assertParseFailure(parser, EMAIL_DESC_AMY + validExpectedPersonString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_EMAIL));
-
-        // multiple addresses
-        assertParseFailure(parser, ADDRESS_DESC_AMY + validExpectedPersonString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_ADDRESS));
-
-        // multiple fields repeated
-        assertParseFailure(parser,
-                validExpectedPersonString + PHONE_DESC_AMY + EMAIL_DESC_AMY + NAME_DESC_AMY + ADDRESS_DESC_AMY
-                        + validExpectedPersonString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME, PREFIX_ADDRESS, PREFIX_EMAIL, PREFIX_PHONE));
-
-        // invalid value followed by valid value
-
-        // invalid name
-        assertParseFailure(parser, INVALID_NAME_DESC + validExpectedPersonString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME));
-
-        // invalid email
-        assertParseFailure(parser, INVALID_EMAIL_DESC + validExpectedPersonString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_EMAIL));
-
-        // invalid phone
-        assertParseFailure(parser, INVALID_PHONE_DESC + validExpectedPersonString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
-
-        // invalid address
-        assertParseFailure(parser, INVALID_ADDRESS_DESC + validExpectedPersonString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_ADDRESS));
-
-        // valid value followed by invalid value
-
-        // invalid name
-        assertParseFailure(parser, validExpectedPersonString + INVALID_NAME_DESC,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME));
-
-        // invalid email
-        assertParseFailure(parser, validExpectedPersonString + INVALID_EMAIL_DESC,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_EMAIL));
-
-        // invalid phone
-        assertParseFailure(parser, validExpectedPersonString + INVALID_PHONE_DESC,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
-
-        // invalid address
-        assertParseFailure(parser, validExpectedPersonString + INVALID_ADDRESS_DESC,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_ADDRESS));
+        assertParseFailure(parser, VALID_ADD_INPUT + " " + PREFIX_NUS_ID + "A1234567C",
+                getErrorMessageForDuplicatePrefixes(PREFIX_NUS_ID));
     }
 
     @Test
     public void parse_optionalFieldsMissing_success() {
-        // zero tags
-        Person expectedPerson = new PersonBuilder(AMY).withTags().build();
-        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY,
-                new AddCommand(expectedPerson));
+        Person expectedPerson = new Person(
+                new Name(VALID_NAME),
+                new Phone(VALID_PHONE),
+                new Email(VALID_EMAIL),
+                new Address("-"),
+                Set.of());
+        assertParseSuccess(parser, VALID_ADD_INPUT, new AddCommand(expectedPerson));
     }
 
     @Test
@@ -142,55 +91,68 @@ public class AddCommandParserTest {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE);
 
         // missing name prefix
-        assertParseFailure(parser, VALID_NAME_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB,
+        assertParseFailure(parser, VALID_NAME + NUS_ID_DESC + ROLE_DESC + SOC_DESC + GITHUB_DESC
+                + EMAIL_DESC + PHONE_DESC + TUTORIAL_DESC,
                 expectedMessage);
 
-        // missing phone prefix
-        assertParseFailure(parser, NAME_DESC_BOB + VALID_PHONE_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB,
-                expectedMessage);
-
-        // missing email prefix
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + VALID_EMAIL_BOB + ADDRESS_DESC_BOB,
-                expectedMessage);
-
-        // missing address prefix
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + VALID_ADDRESS_BOB,
+        // missing tutorial group prefix
+        assertParseFailure(parser, NAME_DESC + NUS_ID_DESC + ROLE_DESC + SOC_DESC + GITHUB_DESC
+                + EMAIL_DESC + PHONE_DESC + " T01",
                 expectedMessage);
 
         // all prefixes missing
-        assertParseFailure(parser, VALID_NAME_BOB + VALID_PHONE_BOB + VALID_EMAIL_BOB + VALID_ADDRESS_BOB,
+        assertParseFailure(parser, VALID_NAME + VALID_NUS_ID + VALID_ROLE + VALID_SOC + VALID_GITHUB
+                + VALID_EMAIL + VALID_PHONE + VALID_TUTORIAL,
                 expectedMessage);
     }
 
     @Test
     public void parse_invalidValue_failure() {
         // invalid name
-        assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Name.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, " " + PREFIX_NAME + "@John" + NUS_ID_DESC + ROLE_DESC + SOC_DESC + GITHUB_DESC
+                + EMAIL_DESC + PHONE_DESC + TUTORIAL_DESC, Name.MESSAGE_CONSTRAINTS);
+
+        // invalid NUS ID
+        assertParseFailure(parser, NAME_DESC + " " + PREFIX_NUS_ID + "Z123" + ROLE_DESC + SOC_DESC + GITHUB_DESC
+                + EMAIL_DESC + PHONE_DESC + TUTORIAL_DESC, ParserUtil.MESSAGE_NUS_ID_CONSTRAINTS);
+
+        // invalid role
+        assertParseFailure(parser, NAME_DESC + NUS_ID_DESC + " " + PREFIX_ROLE + "ta" + SOC_DESC + GITHUB_DESC
+                + EMAIL_DESC + PHONE_DESC + TUTORIAL_DESC, ParserUtil.MESSAGE_ROLE_CONSTRAINTS);
+
+        // invalid SOC username
+        assertParseFailure(parser, NAME_DESC + NUS_ID_DESC + ROLE_DESC + " " + PREFIX_SOC_USERNAME + "Abcde"
+                + GITHUB_DESC + EMAIL_DESC + PHONE_DESC + TUTORIAL_DESC,
+                ParserUtil.MESSAGE_SOC_USERNAME_CONSTRAINTS);
+
+        // invalid GitHub username
+        assertParseFailure(parser, NAME_DESC + NUS_ID_DESC + ROLE_DESC + SOC_DESC
+                + " " + PREFIX_GITHUB_USERNAME + "ab--cd" + EMAIL_DESC + PHONE_DESC + TUTORIAL_DESC,
+                ParserUtil.MESSAGE_GITHUB_USERNAME_CONSTRAINTS);
 
         // invalid phone
-        assertParseFailure(parser, NAME_DESC_BOB + INVALID_PHONE_DESC + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Phone.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, NAME_DESC + NUS_ID_DESC + ROLE_DESC + SOC_DESC + GITHUB_DESC + EMAIL_DESC
+                + " " + PREFIX_PHONE + "12ab" + TUTORIAL_DESC, Phone.MESSAGE_CONSTRAINTS);
 
         // invalid email
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + INVALID_EMAIL_DESC + ADDRESS_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Email.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, NAME_DESC + NUS_ID_DESC + ROLE_DESC + SOC_DESC + GITHUB_DESC
+                + " " + PREFIX_EMAIL + "john@" + PHONE_DESC + TUTORIAL_DESC, Email.MESSAGE_CONSTRAINTS);
 
-        // invalid address
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Address.MESSAGE_CONSTRAINTS);
+        // invalid tutorial group
+        assertParseFailure(parser, NAME_DESC + NUS_ID_DESC + ROLE_DESC + SOC_DESC + GITHUB_DESC
+                + EMAIL_DESC + PHONE_DESC + " " + PREFIX_TUTORIAL_GROUP + "T1",
+                ParserUtil.MESSAGE_TUTORIAL_GROUP_CONSTRAINTS);
 
         // invalid tag
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + INVALID_TAG_DESC + VALID_TAG_FRIEND, Tag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, VALID_ADD_INPUT + " " + PREFIX_TAG + "bad tag", Tag.MESSAGE_CONSTRAINTS);
 
         // two invalid values, only first invalid value reported
-        assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC,
+        assertParseFailure(parser, " " + PREFIX_NAME + "@John" + NUS_ID_DESC + ROLE_DESC + SOC_DESC + GITHUB_DESC
+                + EMAIL_DESC + PHONE_DESC + " " + PREFIX_TUTORIAL_GROUP + "bad",
                 Name.MESSAGE_CONSTRAINTS);
 
         // non-empty preamble
-        assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+        assertParseFailure(parser, " abc" + VALID_ADD_INPUT + TAG_ONE_DESC,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -37,7 +37,8 @@ public class AddressBookParserTest {
     public void parseCommand_add() throws Exception {
         Person person = new PersonBuilder().build();
         AddCommand command = (AddCommand) parser.parseCommand(PersonUtil.getAddCommand(person));
-        assertEquals(new AddCommand(person), command);
+        Person expectedPerson = new PersonBuilder(person).withAddress("-").build();
+        assertEquals(new AddCommand(expectedPerson), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/PersonUtil.java
+++ b/src/test/java/seedu/address/testutil/PersonUtil.java
@@ -1,10 +1,15 @@
 package seedu.address.testutil;
 
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GITHUB_USERNAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NUS_ID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SOC_USERNAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TUTORIAL_GROUP;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 
 import java.util.Set;
 
@@ -17,6 +22,12 @@ import seedu.address.model.tag.Tag;
  * A utility class for Person.
  */
 public class PersonUtil {
+
+    private static final String DEFAULT_NUS_ID = "A1234567B";
+    private static final String DEFAULT_ROLE = "student";
+    private static final String DEFAULT_SOC_USERNAME = "tester1";
+    private static final String DEFAULT_GITHUB_USERNAME = "tester1";
+    private static final String DEFAULT_TUTORIAL_GROUP = "T01";
 
     /**
      * Returns an add command string for adding the {@code person}.
@@ -31,9 +42,13 @@ public class PersonUtil {
     public static String getPersonDetails(Person person) {
         StringBuilder sb = new StringBuilder();
         sb.append(PREFIX_NAME + person.getName().fullName + " ");
-        sb.append(PREFIX_PHONE + person.getPhone().value + " ");
+        sb.append(PREFIX_NUS_ID + DEFAULT_NUS_ID + " ");
+        sb.append(PREFIX_ROLE + DEFAULT_ROLE + " ");
+        sb.append(PREFIX_SOC_USERNAME + DEFAULT_SOC_USERNAME + " ");
+        sb.append(PREFIX_GITHUB_USERNAME + DEFAULT_GITHUB_USERNAME + " ");
         sb.append(PREFIX_EMAIL + person.getEmail().value + " ");
-        sb.append(PREFIX_ADDRESS + person.getAddress().value + " ");
+        sb.append(PREFIX_PHONE + person.getPhone().value + " ");
+        sb.append(PREFIX_TUTORIAL_GROUP + DEFAULT_TUTORIAL_GROUP + " ");
         person.getTags().stream().forEach(
             s -> sb.append(PREFIX_TAG + s.tagName + " ")
         );


### PR DESCRIPTION
Fixes #36 

What this PR does:
- Adds 5 new CLI prefixes to CliSyntax: id/, role/, soc/, gh/, t/
- Adds 5 validation methods to ParserUtil: parseNusId, parseRole, parseSocUsername, parseGithubUsername, parseTutorialGroup
- Updates AddCommandParser to require the new prefix set: n/ id/ role/ soc/ gh/ e/ p/ t/
- Uses a temporary Address("-") stub until the Person model is extended (tracked by TODO comments)
- Restores PREFIX_ADDRESS in CliSyntax with a TODO for removal once edit command migration is complete

Tests updated:
- AddCommandParserTest — fully rewritten for new format
- AddressBookParserTest — aligned expected person to use stub address
- LogicManagerTest — updated storage-exception tests to use new add format via PersonUtil
- PersonUtil — getPersonDetails() updated to emit new prefix set

Not in scope (follow-up PRs):
- Domain model classes (NusId, Role, SocUsername, GithubUsername, TutorialGroup)
- Persisting parsed values into Person
- Migrating edit command away from a/ prefix