### PR TITLE
Make sort command parsing case-insensitive

### DIFF
--- a/src/main/java/cms/logic/parser/SortCommandParser.java
+++ b/src/main/java/cms/logic/parser/SortCommandParser.java
@@ -2,6 +2,8 @@ package cms.logic.parser;
 
 import static cms.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
+import java.util.Locale;
+
 import cms.logic.commands.SortCommand;
 import cms.logic.parser.exceptions.ParseException;
 
@@ -17,10 +19,10 @@ public class SortCommandParser implements Parser<SortCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public SortCommand parse(String args) throws ParseException {
-        String trimmedArgs = args.trim();
-        if (SortCommand.SORT_BY_TUTORIAL_GROUP.equals(trimmedArgs)
-                || SortCommand.SORT_BY_NAME.equals(trimmedArgs)) {
-            return new SortCommand(trimmedArgs);
+        String normalizedArgs = args.trim().toLowerCase(Locale.ROOT);
+        if (SortCommand.SORT_BY_TUTORIAL_GROUP.equals(normalizedArgs)
+                || SortCommand.SORT_BY_NAME.equals(normalizedArgs)) {
+            return new SortCommand(normalizedArgs);
         }
 
         throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));

--- a/src/test/java/cms/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/cms/logic/parser/AddressBookParserTest.java
@@ -173,6 +173,14 @@ public class AddressBookParserTest {
     }
 
     @Test
+    public void parseCommand_sortMixedCaseArguments() throws Exception {
+        assertEquals(new SortCommand(SortCommand.SORT_BY_TUTORIAL_GROUP),
+                parser.parseCommand(SortCommand.COMMAND_WORD + " Tg"));
+        assertEquals(new SortCommand(SortCommand.SORT_BY_NAME),
+                parser.parseCommand(SortCommand.COMMAND_WORD + " NaMe"));
+    }
+
+    @Test
     public void parseCommand_sortInvalidArgument_throwsParseException() {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE);
         assertThrows(ParseException.class, expectedMessage, () -> parser.parseCommand(SortCommand.COMMAND_WORD

--- a/src/test/java/cms/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/cms/logic/parser/SortCommandParserTest.java
@@ -1,0 +1,32 @@
+package cms.logic.parser;
+
+import static cms.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static cms.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static cms.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import cms.logic.commands.SortCommand;
+
+public class SortCommandParserTest {
+
+    private final SortCommandParser parser = new SortCommandParser();
+
+    @Test
+    public void parse_lowercaseArguments_success() {
+        assertParseSuccess(parser, " tg ", new SortCommand(SortCommand.SORT_BY_TUTORIAL_GROUP));
+        assertParseSuccess(parser, " name ", new SortCommand(SortCommand.SORT_BY_NAME));
+    }
+
+    @Test
+    public void parse_mixedCaseArguments_success() {
+        assertParseSuccess(parser, " Tg ", new SortCommand(SortCommand.SORT_BY_TUTORIAL_GROUP));
+        assertParseSuccess(parser, " NaMe ", new SortCommand(SortCommand.SORT_BY_NAME));
+    }
+
+    @Test
+    public void parse_invalidArgument_failure() {
+        assertParseFailure(parser, " invalid ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
+    }
+}


### PR DESCRIPTION
fixes #133 
## Summary
Make the `sort` command parser case-insensitive so it accepts reasonable inputs like `sort Tg` and `sort NaMe`.

## Changes
- Updated `SortCommandParser` to normalize the sort argument to lowercase before validation.
- Preserved existing command behavior by continuing to map accepted inputs to the canonical values `tg` and `name`.
- Added direct parser tests in `SortCommandParserTest` to cover:
  - lowercase `tg`
  - lowercase `name`
  - mixed-case `Tg`
  - mixed-case `NaMe`
  - invalid input rejection
- Kept integration coverage through the existing `AddressBookParserTest`.

## Why
Previously, the parser only accepted exact lowercase `tg` and `name`, which made the command unnecessarily strict and likely to reject reasonable user input.

## Testing
- Added `SortCommandParserTest`.
- Ran `./gradlew check coverage` successfully.

## User-visible behavior
- `sort tg` still works.
- `sort name` still works.
- `sort Tg`, `sort TG`, `sort NaMe`, etc. now work as well.
- Invalid sort arguments are still rejected with the same error message.