### PR TITLE
Edit command Bug Fixes

### DIFF
--- a/src/main/java/cms/logic/commands/EditCommand.java
+++ b/src/main/java/cms/logic/commands/EditCommand.java
@@ -33,6 +33,8 @@ import cms.model.person.Phone;
 import cms.model.person.Role;
 import cms.model.person.SocUsername;
 import cms.model.person.TutorialGroup;
+import cms.model.person.exceptions.DuplicatePersonException;
+import cms.model.person.exceptions.DuplicatePersonFieldException;
 import cms.model.tag.Tag;
 
 /**
@@ -95,11 +97,11 @@ public class EditCommand extends Command {
             throw new CommandException(e.getMessage(), e);
         }
 
-        if (!personToEdit.isSamePerson(editedPerson) && model.hasPerson(editedPerson)) {
-            throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+        try {
+            model.setPerson(personToEdit, editedPerson);
+        } catch (DuplicatePersonException | DuplicatePersonFieldException e) {
+            throw new CommandException(e.getMessage(), e);
         }
-
-        model.setPerson(personToEdit, editedPerson);
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS,
                 Messages.format(editedPerson, model.isMasked())));
     }

--- a/src/test/java/cms/logic/commands/EditCommandTest.java
+++ b/src/test/java/cms/logic/commands/EditCommandTest.java
@@ -30,7 +30,10 @@ import cms.model.AddressBook;
 import cms.model.Model;
 import cms.model.ModelManager;
 import cms.model.UserPrefs;
+import cms.model.person.FieldConflict;
 import cms.model.person.Person;
+import cms.model.person.exceptions.DuplicatePersonException;
+import cms.model.person.exceptions.DuplicatePersonFieldException;
 import cms.testutil.EditPersonDescriptorBuilder;
 import cms.testutil.PersonBuilder;
 
@@ -133,7 +136,23 @@ public class EditCommandTest {
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(firstPerson).build();
         EditCommand editCommand = new EditCommand(INDEX_SECOND_PERSON, descriptor);
 
-        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
+        String expectedMessage = DuplicatePersonException.buildMessage(firstPerson);
+        assertCommandFailure(editCommand, model, expectedMessage);
+    }
+
+    @Test
+    public void execute_conflictingUniqueFieldUnfilteredList_failure() {
+        Person conflictingPerson = model.getFilteredPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
+        String conflictingEmail = conflictingPerson.getEmail().value;
+
+        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder()
+                .withEmail(conflictingEmail)
+                .build();
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
+
+        String expectedMessage = DuplicatePersonFieldException.buildMessage(
+                new FieldConflict(FieldConflict.Type.EMAIL, conflictingPerson));
+        assertCommandFailure(editCommand, model, expectedMessage);
     }
 
     @Test
@@ -145,7 +164,8 @@ public class EditCommandTest {
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON,
                 new EditPersonDescriptorBuilder(personInList).build());
 
-        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
+        String expectedMessage = DuplicatePersonException.buildMessage(personInList);
+        assertCommandFailure(editCommand, model, expectedMessage);
     }
 
     @Test


### PR DESCRIPTION
Fix #130  
Fix #131

This PR fixes two edit-command bugs:
1. Editing from a filtered view no longer clears the active filter.
2. Editing a person to a conflicting unique field now returns a proper command failure message instead of failing without clear user feedback.

What changed
- Removed the forced “show all persons” reset after successful edit, so the current filtered view is preserved.
- Updated `edit` conflict handling to catch model-level duplicate identity/unique-field exceptions and surface them as normal command errors.
- Added/updated `EditCommand` tests for:
  - filtered-view preservation after edit,
  - filtered-view case where edited person still matches,
  - conflicting unique-field edit failure with expected error message,
  - duplicate-person edit failure message behavior.

Why
- Users expect `edit` to behave within the current view context.
- Users should receive actionable error messages for uniqueness conflicts (for example, duplicate email), not silent/unclear failures.

Validation
- Ran targeted Gradle tests for `EditCommandTest` with rerun enabled.
- Result: build successful; regression scenarios for both fixes are covered.