### PR TITLE
Fix bug that cause add command to clear active filters

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -491,7 +491,7 @@ Use this section as a quick checklist when adding or editing command examples an
 <a id="field-phone"></a>
 **`p/PHONE`**
 * Digits only.
-* At least 3 digits.
+* Between 3 and 15 digits.
 * Case sensitivity: not applicable (numeric only).
 * Valid: `p/91234567`
 * Invalid: `p/+6591234567`

--- a/src/main/java/cms/model/ModelManager.java
+++ b/src/main/java/cms/model/ModelManager.java
@@ -117,7 +117,6 @@ public class ModelManager implements Model {
     @Override
     public void addPerson(Person person) {
         addressBook.addPerson(person);
-        updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
     }
 
     @Override

--- a/src/main/java/cms/model/person/Phone.java
+++ b/src/main/java/cms/model/person/Phone.java
@@ -10,8 +10,8 @@ import static java.util.Objects.requireNonNull;
 public class Phone {
 
     public static final String MESSAGE_CONSTRAINTS =
-        "Phone numbers should only contain numbers, and it should be at least 3 digits long";
-    public static final String VALIDATION_REGEX = "\\d{3,}";
+        "Phone numbers should only contain numbers, and it should be between 3 and 15 digits long";
+    public static final String VALIDATION_REGEX = "\\d{3,15}";
     public final String value;
 
     /**

--- a/src/test/java/cms/model/ModelManagerTest.java
+++ b/src/test/java/cms/model/ModelManagerTest.java
@@ -98,6 +98,15 @@ public class ModelManagerTest {
     }
 
     @Test
+    public void addPerson_preservesActiveFilter() {
+        modelManager.updateFilteredPersonList(person -> false);
+
+        modelManager.addPerson(ALICE);
+
+        assertTrue(modelManager.getFilteredPersonList().isEmpty());
+    }
+
+    @Test
     public void getFilteredPersonList_modifyList_throwsUnsupportedOperationException() {
         assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredPersonList().remove(0));
     }

--- a/src/test/java/cms/model/person/PhoneTest.java
+++ b/src/test/java/cms/model/person/PhoneTest.java
@@ -30,6 +30,7 @@ public class PhoneTest {
         assertFalse(Phone.isValidPhone("")); // empty string
         assertFalse(Phone.isValidPhone("-")); // hyphen
         assertFalse(Phone.isValidPhone("91")); // less than 3 numbers
+        assertFalse(Phone.isValidPhone("1234567890123456")); // more than 15 digits
         assertFalse(Phone.isValidPhone("phone")); // non-numeric
         assertFalse(Phone.isValidPhone("9011p041")); // alphabets within digits
         assertFalse(Phone.isValidPhone("9312 1534")); // spaces within digits
@@ -37,7 +38,7 @@ public class PhoneTest {
         // valid phone numbers
         assertTrue(Phone.isValidPhone("911")); // exactly 3 numbers
         assertTrue(Phone.isValidPhone("93121534"));
-        assertTrue(Phone.isValidPhone("124293842033123")); // long phone numbers
+        assertTrue(Phone.isValidPhone("123456789012345")); // exactly 15 digits
     }
 
     @Test
@@ -71,6 +72,7 @@ public class PhoneTest {
         assertDoesNotThrow(() -> new Phone("911"));
         assertDoesNotThrow(() -> new Phone("91234567"));
         assertDoesNotThrow(() -> new Phone("123456"));
+        assertDoesNotThrow(() -> new Phone("123456789012345")); // 15 digits
         assertDoesNotThrow(() -> new Phone(" 91234567 ")); // trims surrounding spaces
     }
 
@@ -82,6 +84,7 @@ public class PhoneTest {
         assertThrows(IllegalArgumentException.class, () -> new Phone("9123-4567")); // dash
         assertThrows(IllegalArgumentException.class, () -> new Phone("+6591234567")); // country code
         assertThrows(IllegalArgumentException.class, () -> new Phone("9123456a")); // letter
+        assertThrows(IllegalArgumentException.class, () -> new Phone("1234567890123456")); // too long
         assertThrows(IllegalArgumentException.class, () -> new Phone("")); // empty
     }
 


### PR DESCRIPTION
## Summary
This PR fixes `add` so it preserves the current filter state and tightens phone number validation.

## Changes
- `add` no longer resets the filtered person list after inserting a person.
- Phone numbers are now limited to 3 to 15 digits.
- Updated unit tests for filter and phone validation.
- Updated the user guide phone constraint note.