### PR TITLE
Fix find a/ tutorial group matching with T prefix

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -269,7 +269,7 @@ Sorts all persons by name or tutorial group.
 * `sort name`
 * `sort tg`
 
-**Constraints:** The sort key must be either `name` or `tg`.
+**Constraints:** The sort key must be either `name` or `tg`. (case-insensitive)
 
 **Examples:**
 * `sort NAME`

--- a/src/main/java/cms/model/person/AllFieldsContainsKeywordsPredicate.java
+++ b/src/main/java/cms/model/person/AllFieldsContainsKeywordsPredicate.java
@@ -23,6 +23,7 @@ public class AllFieldsContainsKeywordsPredicate implements Predicate<Person> {
             return false;
         }
         for (String keyword : keywords) {
+            String tutorialKeyword = keyword.replaceFirst("(?i)^T(?=0*[1-9][0-9]?$)", "");
             boolean matchesName = StringUtil.containsWordIgnoreCase(person.getName().fullName, keyword);
             boolean matchesNusMatric = person.getNusMatric() != null
                     && person.getNusMatric().value.equalsIgnoreCase(keyword);
@@ -35,8 +36,8 @@ public class AllFieldsContainsKeywordsPredicate implements Predicate<Person> {
             boolean matchesRole = person.getRole() != null
                     && person.getRole().value.equalsIgnoreCase(keyword);
             boolean matchesTutorial = person.getTutorialGroup() != null
-                    && TutorialGroup.isValidTutorialGroup(keyword)
-                    && person.getTutorialGroup().toString().equals(TutorialGroup.canonicalise(keyword));
+                    && TutorialGroup.isValidTutorialGroup(tutorialKeyword)
+                    && person.getTutorialGroup().toString().equals(TutorialGroup.canonicalise(tutorialKeyword));
             boolean matchesTag = person.getTags().stream()
                     .anyMatch(tag -> tag.tagName.equalsIgnoreCase(keyword));
 

--- a/src/test/java/cms/model/person/AllFieldsContainsKeywordsPredicateTest.java
+++ b/src/test/java/cms/model/person/AllFieldsContainsKeywordsPredicateTest.java
@@ -153,6 +153,10 @@ public class AllFieldsContainsKeywordsPredicateTest {
         AllFieldsContainsKeywordsPredicate leadingZero = new AllFieldsContainsKeywordsPredicate(
                 Collections.singletonList("010"));
         assertTrue(leadingZero.test(person));
+
+        AllFieldsContainsKeywordsPredicate prefixed = new AllFieldsContainsKeywordsPredicate(
+                Collections.singletonList("T10"));
+        assertTrue(prefixed.test(person));
     }
 
     @Test


### PR DESCRIPTION
Fix #244 

## Summary
Fixes `find a/` so tutorial group queries with the displayed `T` prefix work as expected.

Before this change:
- `find a/01` could match tutorial group `01`
- `find a/T01` would not match the same person

After this change:
- both `find a/01` and `find a/T01` match tutorial group `01`

## What Changed
- Updated the all-fields find predicate to accept tutorial-group keywords in `T01`-style format
- Kept the change narrowly scoped so only tutorial-group-shaped keywords are normalized
- Added a regression test to cover prefixed tutorial group search

## Why
Tutorial groups are shown in the UI as `T01`, `T02`, etc., so users naturally search using that format. This makes `find a/` behave consistently with what users see on screen.

## Testing
- Added unit test coverage for `T10` matching tutorial group `10`
- Could not run Gradle tests in the sandbox because the Gradle wrapper needed to download dependencies and network access was blocked
