### PR TITLE
Fix import command bugs

### DIFF
--- a/src/main/java/cms/logic/commands/ImportCommand.java
+++ b/src/main/java/cms/logic/commands/ImportCommand.java
@@ -269,5 +269,3 @@ public class ImportCommand extends Command {
         return java.util.Objects.hash(importFilePath, keepPolicy);
     }
 }
-
-

--- a/src/main/java/cms/logic/commands/ImportCommand.java
+++ b/src/main/java/cms/logic/commands/ImportCommand.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Set;
 
 import cms.commons.exceptions.DataLoadingException;
+import cms.commons.exceptions.IllegalValueException;
 import cms.logic.commands.exceptions.CommandException;
 import cms.model.AddressBook;
 import cms.model.Model;
@@ -43,6 +44,8 @@ public class ImportCommand extends Command {
             "Import file is empty or not a valid Course Management System data file.";
     public static final String MESSAGE_INVALID_DATA =
             "Import file contains invalid Course Management System data.";
+    public static final String MESSAGE_INVALID_DATA_DETAILS_FORMAT =
+            "%s Details: %s";
     public static final String MESSAGE_STORAGE_CONTEXT_REQUIRED =
             "Import command requires storage context.";
     public static final String MESSAGE_KEEP_REQUIRED_NON_EMPTY = "Current data is non-empty. "
@@ -105,7 +108,7 @@ public class ImportCommand extends Command {
             importedAddressBook = storage.readAddressBook(importFilePath)
                     .orElseThrow(() -> new CommandException(MESSAGE_EMPTY_OR_INVALID_FILE));
         } catch (DataLoadingException dle) {
-            throw new CommandException(MESSAGE_INVALID_DATA, dle);
+            throw new CommandException(buildInvalidDataMessage(dle), dle);
         }
 
         boolean hasCurrentData = !model.getAddressBook().getPersonList().isEmpty();
@@ -230,6 +233,14 @@ public class ImportCommand extends Command {
         return details.toString();
     }
 
+    private String buildInvalidDataMessage(DataLoadingException dataLoadingException) {
+        Throwable cause = dataLoadingException.getCause();
+        if (!(cause instanceof IllegalValueException) || cause.getMessage() == null || cause.getMessage().isEmpty()) {
+            return MESSAGE_INVALID_DATA;
+        }
+        return String.format(MESSAGE_INVALID_DATA_DETAILS_FORMAT, MESSAGE_INVALID_DATA, cause.getMessage());
+    }
+
     public Path getImportFilePath() {
         return importFilePath;
     }
@@ -258,3 +269,5 @@ public class ImportCommand extends Command {
         return java.util.Objects.hash(importFilePath, keepPolicy);
     }
 }
+
+

--- a/src/main/java/cms/logic/commands/ImportCommand.java
+++ b/src/main/java/cms/logic/commands/ImportCommand.java
@@ -56,6 +56,10 @@ public class ImportCommand extends Command {
             "incoming '%s' conflicts with current '%s' by NUS Matric (%s)";
     public static final String MESSAGE_FIELD_CONFLICT_FORMAT =
             "incoming '%s' conflicts with current '%s' by %s (%s)";
+    public static final String MESSAGE_MULTIPLE_CONFLICTS_FORMAT =
+            "Import aborted: incoming '%s' conflicts with multiple current persons (%d). "
+            + "Please resolve conflicts manually before using keep/incoming.";
+    private static final String MESSAGE_MULTIPLE_CONFLICTS_DETAILS_HEADER = "\nConflicting entries:";
     private static final String MESSAGE_CONFLICT_PREVIEW_HEADER = "\nConflicting entries detected:";
     private static final int CONFLICT_PREVIEW_LIMIT = 5;
 
@@ -126,6 +130,10 @@ public class ImportCommand extends Command {
 
             if (keepPolicy == KeepPolicy.CURRENT) {
                 continue;
+            }
+
+            if (conflictingPersons.size() > 1) {
+                throw new CommandException(buildMultipleConflictsMessage(incomingPerson, conflictingPersons));
             }
 
             for (Person conflictingPerson : conflictingPersons) {
@@ -207,6 +215,19 @@ public class ImportCommand extends Command {
         return String.format(MESSAGE_FIELD_CONFLICT_FORMAT,
                 incomingPerson.getName(), existingPerson.getName(),
                 fieldConflict.getFieldName(), fieldConflict.getFieldValue());
+    }
+
+    private String buildMultipleConflictsMessage(Person incomingPerson, List<Person> conflictingPersons) {
+        StringBuilder details = new StringBuilder(String.format(
+                MESSAGE_MULTIPLE_CONFLICTS_FORMAT, incomingPerson.getName(), conflictingPersons.size()));
+        details.append(MESSAGE_MULTIPLE_CONFLICTS_DETAILS_HEADER);
+        for (Person conflictingPerson : conflictingPersons) {
+            String conflictDescription = getConflictDescription(incomingPerson, conflictingPerson);
+            if (conflictDescription != null) {
+                details.append("\n- ").append(conflictDescription);
+            }
+        }
+        return details.toString();
     }
 
     public Path getImportFilePath() {

--- a/src/test/java/cms/logic/LogicManagerTest.java
+++ b/src/test/java/cms/logic/LogicManagerTest.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import cms.commons.exceptions.DataLoadingException;
+import cms.commons.exceptions.IllegalValueException;
 import cms.logic.commands.AddCommand;
 import cms.logic.commands.CommandResult;
 import cms.logic.commands.ExportCommand;
@@ -306,6 +307,31 @@ public class LogicManagerTest {
 
         assertCommandFailure(importCommand, CommandException.class,
             "Import file contains invalid Course Management System data.");
+    }
+
+    @Test
+    public void executeImportCommandInvalidDataShowsDetailsForIllegalValue() {
+        Path prefPath = temporaryFolder.resolve("addressBook.json");
+
+        JsonAddressBookStorage addressBookStorage = new JsonAddressBookStorage(prefPath) {
+            @Override
+            public Optional<ReadOnlyAddressBook> readAddressBook(Path filePath) throws DataLoadingException {
+                throw new DataLoadingException(new IllegalValueException("duplicate field in persons list"));
+            }
+        };
+
+        JsonUserPrefsStorage userPrefsStorage =
+                new JsonUserPrefsStorage(temporaryFolder.resolve("ExceptionUserPrefs.json"));
+        StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage);
+        logic = new LogicManager(model, storage);
+
+        Path importPath = temporaryFolder.resolve("imports").resolve("invalid.json");
+        String importCommand = ImportCommand.COMMAND_WORD + " \"" + importPath + "\"";
+
+        CommandException thrownException = org.junit.jupiter.api.Assertions.assertThrows(
+                CommandException.class, () -> logic.execute(importCommand));
+        assertTrue(thrownException.getMessage().contains(ImportCommand.MESSAGE_INVALID_DATA));
+        assertTrue(thrownException.getMessage().contains("duplicate field in persons list"));
     }
 
     @Test

--- a/src/test/java/cms/logic/LogicManagerTest.java
+++ b/src/test/java/cms/logic/LogicManagerTest.java
@@ -335,6 +335,30 @@ public class LogicManagerTest {
     }
 
     @Test
+    public void executeImportCommandInvalidDataWithEmptyIllegalValueMessageShowsGenericMessage() {
+        Path prefPath = temporaryFolder.resolve("addressBook.json");
+
+        JsonAddressBookStorage addressBookStorage = new JsonAddressBookStorage(prefPath) {
+            @Override
+            public Optional<ReadOnlyAddressBook> readAddressBook(Path filePath) throws DataLoadingException {
+                throw new DataLoadingException(new IllegalValueException(""));
+            }
+        };
+
+        JsonUserPrefsStorage userPrefsStorage =
+                new JsonUserPrefsStorage(temporaryFolder.resolve("ExceptionUserPrefs.json"));
+        StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage);
+        logic = new LogicManager(model, storage);
+
+        Path importPath = temporaryFolder.resolve("imports").resolve("invalid.json");
+        String importCommand = ImportCommand.COMMAND_WORD + " \"" + importPath + "\"";
+
+        CommandException thrownException = org.junit.jupiter.api.Assertions.assertThrows(
+                CommandException.class, () -> logic.execute(importCommand));
+        assertEquals(ImportCommand.MESSAGE_INVALID_DATA, thrownException.getMessage());
+    }
+
+    @Test
     public void execute_importCommandWithCurrentDataAndNoKeep_throwsCommandException() throws Exception {
         logic.execute(AddCommand.COMMAND_WORD + NAME_DESC_AMY + NUSMATRIC_DESC_AMY + ROLE_DESC_AMY
                 + SOCUSERNAME_DESC_AMY + GITHUBUSERNAME_DESC_AMY + PHONE_DESC_AMY

--- a/src/test/java/cms/logic/LogicManagerTest.java
+++ b/src/test/java/cms/logic/LogicManagerTest.java
@@ -480,6 +480,33 @@ public class LogicManagerTest {
     }
 
     @Test
+    public void executeImportKeepIncomingAmbiguousConflictThrowsCommandException()
+            throws Exception {
+        Person existingPersonOne = new PersonBuilder(ALICE).build();
+        Person existingPersonTwo = new PersonBuilder(BENSON).build();
+        model.addPerson(existingPersonOne);
+        model.addPerson(existingPersonTwo);
+
+        Person ambiguousIncomingPerson = new PersonBuilder(CARL)
+                .withEmail(existingPersonOne.getEmail().toString())
+                .withSocUsername(existingPersonTwo.getSocUsername().toString())
+                .build();
+        Path importPath = createImportFileWithSinglePerson(ambiguousIncomingPerson);
+        String importCommand = buildImportCommand(importPath.toAbsolutePath().normalize(), "keep/incoming");
+
+        CommandException thrownException = org.junit.jupiter.api.Assertions.assertThrows(
+                CommandException.class, () -> logic.execute(importCommand));
+        assertTrue(thrownException.getMessage().contains("conflicts with multiple current persons"));
+        assertTrue(thrownException.getMessage().contains(existingPersonOne.getName().toString()));
+        assertTrue(thrownException.getMessage().contains(existingPersonTwo.getName().toString()));
+        assertTrue(thrownException.getMessage().contains("by email"));
+        assertTrue(thrownException.getMessage().contains("by SOC username"));
+        assertTrue(model.getFilteredPersonList().contains(existingPersonOne));
+        assertTrue(model.getFilteredPersonList().contains(existingPersonTwo));
+        assertEquals(2, model.getFilteredPersonList().size());
+    }
+
+    @Test
     public void getFilteredPersonList_modifyList_throwsUnsupportedOperationException() {
         assertThrows(UnsupportedOperationException.class, () -> logic.getFilteredPersonList().remove(0));
     }

--- a/src/test/java/cms/logic/LogicManagerTest.java
+++ b/src/test/java/cms/logic/LogicManagerTest.java
@@ -359,6 +359,30 @@ public class LogicManagerTest {
     }
 
     @Test
+    public void executeImportCommandInvalidDataWithNullIllegalValueMessageShowsGenericMessage() {
+        Path prefPath = temporaryFolder.resolve("addressBook.json");
+
+        JsonAddressBookStorage addressBookStorage = new JsonAddressBookStorage(prefPath) {
+            @Override
+            public Optional<ReadOnlyAddressBook> readAddressBook(Path filePath) throws DataLoadingException {
+                throw new DataLoadingException(new IllegalValueException(null));
+            }
+        };
+
+        JsonUserPrefsStorage userPrefsStorage =
+                new JsonUserPrefsStorage(temporaryFolder.resolve("ExceptionUserPrefs.json"));
+        StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage);
+        logic = new LogicManager(model, storage);
+
+        Path importPath = temporaryFolder.resolve("imports").resolve("invalid.json");
+        String importCommand = ImportCommand.COMMAND_WORD + " \"" + importPath + "\"";
+
+        CommandException thrownException = org.junit.jupiter.api.Assertions.assertThrows(
+                CommandException.class, () -> logic.execute(importCommand));
+        assertEquals(ImportCommand.MESSAGE_INVALID_DATA, thrownException.getMessage());
+    }
+
+    @Test
     public void execute_importCommandWithCurrentDataAndNoKeep_throwsCommandException() throws Exception {
         logic.execute(AddCommand.COMMAND_WORD + NAME_DESC_AMY + NUSMATRIC_DESC_AMY + ROLE_DESC_AMY
                 + SOCUSERNAME_DESC_AMY + GITHUBUSERNAME_DESC_AMY + PHONE_DESC_AMY

--- a/src/test/java/cms/logic/commands/ImportCommandTest.java
+++ b/src/test/java/cms/logic/commands/ImportCommandTest.java
@@ -13,12 +13,16 @@ import static cms.logic.commands.CommandTestUtil.VALID_SOCUSERNAME_AMY;
 import static cms.logic.commands.CommandTestUtil.VALID_SOCUSERNAME_BOB;
 import static cms.logic.commands.CommandTestUtil.VALID_TUTORIALGROUP_AMY;
 import static cms.logic.commands.CommandTestUtil.VALID_TUTORIALGROUP_BOB;
+import static cms.testutil.TypicalPersons.ALICE;
+import static cms.testutil.TypicalPersons.BENSON;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.reflect.Method;
 import java.nio.file.Path;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -106,7 +110,30 @@ public class ImportCommandTest {
         assertTrue(model.getFilteredPersonList().contains(incomingPerson));
         assertFalse(model.getFilteredPersonList().contains(existingPerson));
     }
+    @Test
+    public void buildMultipleConflictsMessage_skipsNonConflictingPersons() throws Exception {
+        ImportCommand importCommand = new ImportCommand(Path.of("data/first.json"), KeepPolicy.INCOMING);
+        Person incomingPerson = new PersonBuilder(BENSON).build();
+        Person nonConflictingPerson = new PersonBuilder(ALICE).build();
 
+        Method method = ImportCommand.class.getDeclaredMethod(
+                "buildMultipleConflictsMessage", Person.class, List.class);
+        method.setAccessible(true);
+
+        String message = (String) method.invoke(importCommand, incomingPerson, List.of(nonConflictingPerson));
+
+        assertTrue(message.contains("conflicts with multiple current persons (1)"));
+        assertFalse(message.contains("\n- "));
+    }
+
+    @Test
+    public void getters_returnConfiguredValues() {
+        Path path = Path.of("data/first.json");
+        ImportCommand importCommand = new ImportCommand(path, KeepPolicy.INCOMING);
+
+        assertEquals(path, importCommand.getImportFilePath());
+        assertEquals(KeepPolicy.INCOMING, importCommand.getKeepPolicy());
+    }
     @Test
     public void equals() {
         ImportCommand importFirstCommand = new ImportCommand(Path.of("data/first.json"),
@@ -126,3 +153,4 @@ public class ImportCommandTest {
         assertFalse(importFirstCommand.equals(null));
     }
 }
+


### PR DESCRIPTION
Fixes #217 

This PR fixes a data-loss bug in `import ... keep/incoming` where one imported person could silently remove multiple existing people if they conflicted on different unique fields. The import flow now rejects ambiguous multi-conflict cases instead of guessing a resolution, preventing accidental deletion of valid records.

It also improves the error message for that case so the user can see the exact conflicting entries and which fields caused the conflict, making it easier to resolve the issue manually before retrying the import.

Verification
- Ran Checkstyle for main and test sources
- Ran the targeted [LogicManagerTest] regression coverage for the import behavior

Fixes #297 
Additionally, this PR also fixes the Import command to give more specific error messages when failing to import data compared to hiding it behind the generic error message.