### PR TITLE
Improve tag command error message for invalid action casing

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -61,7 +61,7 @@ Action | Format
 **Edit** | `edit INDEX [n/NAME] [m/NUS_MATRIC] [role/ROLE] [soc/SOC_USERNAME] [gh/GITHUB_USERNAME] [e/EMAIL] [p/PHONE] [t/TUTORIAL_GROUP] [tag/TAG]...`<br><br>e.g. `edit 2 p/98765432 e/johndoe@example.com`
 **Delete** | `delete id/INDEX [MORE_INDEXES]...`<br>`delete m/NUS_MATRIC [MORE_NUS_MATRICS]...`<br><br>e.g. `delete id/1 3 5`
 **Find** | `find a/KEYWORD [MORE_KEYWORDS]...`<br>`find n/KEYWORD [MORE_NAME_KEYWORDS]...`<br>`find m/NUS_MATRIC [MORE_NUS_MATRICS]...`<br><br>e.g. `find n/jane n/eunice m/A0123456J`
-**Tag** | `tag add id/INDEX [MORE_INDEXES]... tag/TAG [MORE_TAGS]...`<br>`tag add m/NUS_MATRIC [MORE_NUS_MATRICS]... tag/TAG [MORE_TAGS]...`<br>`tag delete id/INDEX [MORE_INDEXES]... tag/TAG [MORE_TAGS]...`<br>`tag delete m/NUS_MATRIC [MORE_NUS_MATRICS]... tag/TAG [MORE_TAGS]...`<br><br>e.g. `tag add id/1 2 tag/friend tutor`
+**Tag** | `tag add id/INDEX [MORE_INDEXES]... tag/TAG [MORE_TAGS]...`<br>`tag add m/NUS_MATRIC [MORE_NUS_MATRICS]... tag/TAG [MORE_TAGS]...`<br>`tag delete id/INDEX [MORE_INDEXES]... tag/TAG [MORE_TAGS]...`<br>`tag delete m/NUS_MATRIC [MORE_NUS_MATRICS]... tag/TAG [MORE_TAGS]...`<br><br>Use lowercase `add` or `delete` only.<br><br>e.g. `tag add id/1 2 tag/friend tutor`
 **Filter** | `filter [tag/TAG]... [t/TUTORIAL_GROUP_NUMBER]`<br><br>e.g. `filter tag/friends t/01`
 **Sort** | `sort tg`<br>`sort name`<br><br>e.g. `sort tg`
 **Import** | `import "FILE_PATH" [keep/current|keep/incoming]`<br><br>e.g. `import "data/addressbook.json" keep/current`
@@ -220,6 +220,7 @@ Adds or removes one or more tags from one or more persons.
 
 **Constraints:**
 * The action must be either `add` or `delete`.
+* The action is case-sensitive and must be lowercase. For example, `tag ADD ...` and `tag Delete ...` are invalid.
 * Target persons must be specified by either displayed indexes (`id/`) or NUS Matrics (`m/`), not both.
 * Each index must refer to the current displayed list and be a positive integer.
 * At least one target person and one tag must be provided.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -236,6 +236,10 @@ Adds or removes one or more tags from one or more persons.
 **Expected result:**
 * The selected persons' tags are updated.
 * The Result Display confirms the tag operation.
+* If `tag delete` does not find any of the specified tags on the targeted persons, no changes are made and the Result Display shows `No specified tags were removed from the targeted persons.`
+
+Example: if person `id/3` has no `python` tag, running `tag delete id/3 tag/python` shows
+`No specified tags were removed from the targeted persons.`
 
 ### Filtering students / tutors : `filter`
 

--- a/src/main/java/cms/logic/commands/TagCommand.java
+++ b/src/main/java/cms/logic/commands/TagCommand.java
@@ -31,6 +31,8 @@ public class TagCommand extends Command {
     public static final String ACTION_ADD = "add";
     public static final String ACTION_DELETE = "delete";
 
+    public static final String MESSAGE_INVALID_ACTION =
+            "Tag action must be lowercase and either 'add' or 'delete'.";
     public static final String MESSAGE_EMPTY_INDEX_LIST = "At least one person index must be provided.";
     public static final String MESSAGE_EMPTY_NUS_MATRIC_LIST = "At least one NUS Matric must be provided.";
     public static final String MESSAGE_EMPTY_TAG_LIST = "At least one tag must be provided.";

--- a/src/main/java/cms/logic/parser/TagCommandParser.java
+++ b/src/main/java/cms/logic/parser/TagCommandParser.java
@@ -61,6 +61,9 @@ public class TagCommandParser implements Parser<TagCommand> {
                     splitValues(argMultimap.getAllValues(PREFIX_MATRIC)));
             return TagCommand.byNusMatrics(action, nusMatrics, tags);
         } catch (ParseException pe) {
+            if (TagCommand.MESSAGE_INVALID_ACTION.equals(pe.getMessage())) {
+                throw pe;
+            }
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, TagCommand.MESSAGE_USAGE), pe);
         }
     }
@@ -74,7 +77,7 @@ public class TagCommandParser implements Parser<TagCommand> {
             return Action.DELETE;
         }
 
-        throw new ParseException(TagCommand.MESSAGE_USAGE);
+        throw new ParseException(TagCommand.MESSAGE_INVALID_ACTION);
     }
 
     private List<Tag> parseTags(List<String> tagValues) throws ParseException {

--- a/src/test/java/cms/logic/parser/TagCommandParserTest.java
+++ b/src/test/java/cms/logic/parser/TagCommandParserTest.java
@@ -55,13 +55,19 @@ public class TagCommandParserTest {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, TagCommand.MESSAGE_USAGE);
 
         assertParseFailure(parser, "add", expectedMessage);
-        assertParseFailure(parser, "rename id/1 tag/friend", expectedMessage);
         assertParseFailure(parser, "add 1 tag/friend", expectedMessage);
         assertParseFailure(parser, "add id/1 m/" + VALID_NUSMATRIC_AMY + " tag/friend", expectedMessage);
         assertParseFailure(parser, "delete id/1", expectedMessage);
         assertParseFailure(parser, "add tag/friend", expectedMessage);
         assertParseFailure(parser, "add id/1 tag/   ", expectedMessage);
         assertParseFailure(parser, "delete id/1 x", expectedMessage);
+    }
+
+    @Test
+    public void parse_invalidActionCase_throwsSpecificParseException() {
+        assertParseFailure(parser, "ADD id/1 tag/friend", TagCommand.MESSAGE_INVALID_ACTION);
+        assertParseFailure(parser, "Delete id/1 tag/friend", TagCommand.MESSAGE_INVALID_ACTION);
+        assertParseFailure(parser, "rename id/1 tag/friend", TagCommand.MESSAGE_INVALID_ACTION);
     }
 
     @Test


### PR DESCRIPTION
fix #266, #250 , #242 
## Summary

Improves the `tag` command’s error handling when the action word is invalid or wrongly cased.

Previously, inputs such as `tag ADD ...` or `tag Delete ...` were reported as a generic command format error. This PR updates the parser to return a clearer, action-specific message stating that the action must be lowercase and either `add` or `delete`.

## Changes Made

- Added a specific `TagCommand` error message for invalid actions
- Updated `TagCommandParser` so invalid action errors are not wrapped as generic format errors
- Added parser tests for:
  - wrong-cased actions such as `ADD` and `Delete`
  - unsupported actions such as `rename`
- Updated the User Guide to explicitly state that `tag` actions are case-sensitive and must be lowercase

## Rationale

This makes the feedback more accurate and helpful for users. In these cases, the problem is not the overall command format, but the invalid action token.

## Testing

- Ran `./gradlew test --tests cms.logic.parser.TagCommandParserTest`
