### PR TITLE
Improve error message for invalid edit prefix

### DIFF
--- a/src/main/java/cms/logic/parser/EditCommandParser.java
+++ b/src/main/java/cms/logic/parser/EditCommandParser.java
@@ -46,6 +46,10 @@ public class EditCommandParser implements Parser<EditCommand> {
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
+            String preamble = argMultimap.getPreamble().trim();
+            if (preamble.matches("\\d+\\s+\\S+/.*")) {
+                throw new ParseException("Unsupported prefix for edit command: " + preamble.split("\\s+")[1], pe);
+            }
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
         }
 

--- a/src/test/java/cms/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/cms/logic/parser/EditCommandParserTest.java
@@ -55,6 +55,7 @@ public class EditCommandParserTest {
 
     private static final String MESSAGE_INVALID_FORMAT =
             String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE);
+    private static final String MESSAGE_UNSUPPORTED_PREFIX = "Unsupported prefix for edit command: %1$s";
 
     private EditCommandParser parser = new EditCommandParser();
 
@@ -82,7 +83,7 @@ public class EditCommandParserTest {
         assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT);
 
         // invalid prefix being parsed as preamble
-        assertParseFailure(parser, "1 i/ string", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "1 i/ string", String.format(MESSAGE_UNSUPPORTED_PREFIX, "i/"));
     }
 
     @Test


### PR DESCRIPTION
Fix #268

## PR Summary

### Problem
The edit command returned a generic invalid-format error for inputs with unsupported prefixes (for example, `edit 1 r/tutor`), which could mislead users into thinking the index was wrong instead of the prefix.

### What Changed
- Updated edit parsing to detect the specific case where:
  - the first token is a valid index, and
  - the following token looks like an unsupported prefix.
- For that case, the parser now returns a targeted message:
  - `Unsupported prefix for edit command: <prefix>`
- Existing behavior for other malformed edit inputs is unchanged (still uses the standard invalid-format message).

### Files Updated
- EditCommandParser.java
- EditCommandParserTest.java

### Tests
- Ran focused parser tests:
  - `.gradlew.bat test --tests cms.logic.parser.EditCommandParserTest`
- Result: pass