### PR TITLE
Enhance import command feedback with detailed processing statistics

### DIFF
--- a/src/main/java/cms/logic/commands/ImportCommand.java
+++ b/src/main/java/cms/logic/commands/ImportCommand.java
@@ -117,12 +117,14 @@ public class ImportCommand extends Command {
         }
 
         AddressBook mergedAddressBook = new AddressBook(model.getAddressBook());
+        int overlapCount = 0;
         for (Person incomingPerson : importedAddressBook.getPersonList()) {
             List<Person> conflictingPersons = findConflictingPersons(mergedAddressBook, incomingPerson);
             if (conflictingPersons.isEmpty()) {
                 mergedAddressBook.addPerson(incomingPerson);
                 continue;
             }
+            overlapCount++;
 
             if (keepPolicy == KeepPolicy.CURRENT) {
                 continue;
@@ -138,9 +140,15 @@ public class ImportCommand extends Command {
         model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
 
         if (keepPolicy == KeepPolicy.CURRENT) {
-            return new CommandResult(String.format(MESSAGE_KEEP_CURRENT_SUCCESS, importFilePath));
+            return new CommandResult(String.format(MESSAGE_KEEP_CURRENT_SUCCESS
+                + " (%d added, %d skipped, %d processed)", importFilePath,
+                importedAddressBook.getPersonList().size() - overlapCount, overlapCount,
+                importedAddressBook.getPersonList().size()));
         }
-        return new CommandResult(String.format(MESSAGE_KEEP_INCOMING_SUCCESS, importFilePath));
+        return new CommandResult(String.format(MESSAGE_KEEP_INCOMING_SUCCESS
+            + " (%d added, %d replaced, %d processed)", importFilePath,
+            importedAddressBook.getPersonList().size() - overlapCount, overlapCount,
+            importedAddressBook.getPersonList().size()));
     }
 
     /**

--- a/src/test/java/cms/logic/LogicManagerTest.java
+++ b/src/test/java/cms/logic/LogicManagerTest.java
@@ -440,7 +440,8 @@ public class LogicManagerTest {
         String importCommand = buildImportCommand(normalizedImportPath, "keep/current");
         CommandResult result = logic.execute(importCommand);
 
-        assertEquals(String.format(ImportCommand.MESSAGE_KEEP_CURRENT_SUCCESS, normalizedImportPath),
+        assertEquals(String.format(ImportCommand.MESSAGE_KEEP_CURRENT_SUCCESS
+                        + " (%d added, %d skipped, %d processed)", normalizedImportPath, 1, 1, 2),
             result.getFeedbackToUser());
         assertEquals(2, model.getFilteredPersonList().size());
         assertTrue(model.getFilteredPersonList().contains(expectedCurrentPerson));
@@ -472,7 +473,8 @@ public class LogicManagerTest {
         String importCommand = buildImportCommand(normalizedImportPath, "keep/incoming");
         CommandResult result = logic.execute(importCommand);
 
-        assertEquals(String.format(ImportCommand.MESSAGE_KEEP_INCOMING_SUCCESS, normalizedImportPath),
+        assertEquals(String.format(ImportCommand.MESSAGE_KEEP_INCOMING_SUCCESS
+                + " (%d added, %d replaced, %d processed)", normalizedImportPath, 1, 1, 2),
                 result.getFeedbackToUser());
         assertEquals(2, model.getFilteredPersonList().size());
         assertTrue(model.getFilteredPersonList().contains(conflictingIncomingPerson));

--- a/src/test/java/cms/logic/commands/ImportCommandTest.java
+++ b/src/test/java/cms/logic/commands/ImportCommandTest.java
@@ -101,7 +101,9 @@ public class ImportCommandTest {
 
         CommandResult result = importCommand.execute(model, storage);
 
-        assertEquals(String.format(ImportCommand.MESSAGE_KEEP_INCOMING_SUCCESS, path), result.getFeedbackToUser());
+        assertEquals(String.format(ImportCommand.MESSAGE_KEEP_INCOMING_SUCCESS
+                        + " (%d added, %d replaced, %d processed)", path, 0, 1, 1),
+                result.getFeedbackToUser());
         assertEquals(1, model.getFilteredPersonList().size());
         assertTrue(model.getFilteredPersonList().contains(incomingPerson));
         assertFalse(model.getFilteredPersonList().contains(existingPerson));


### PR DESCRIPTION
Fix #252 

**PR Summary**

This PR improves the feedback shown after an import so users get a clearer summary of what changed. For merge imports, the success message now includes how many records were added, skipped, or replaced, along with the total number processed. Imports into an empty CMS keep the existing success message.

I also updated the affected tests to match the new feedback format and verified the change with targeted Gradle tests. Relevant implementation is in ImportCommand.java.